### PR TITLE
Add note about `Random` class

### DIFF
--- a/as2.md
+++ b/as2.md
@@ -134,7 +134,10 @@ Haskell has one available in the `System.Random` library. Random number
 generators need to have access to a piece of state called the seed, as such
 the random number generator runs in a monad, the `IO` monad to be exact.
 
-**Exercise 2:** Give `Random` instances for `Coin` and `Dice`.
+**Exercise 2:** Give `Random` instances for `Coin` and `Dice`. (The `Random`
+class has been largely superseded by other classes in the `random` package with
+a different design, but `Random` is more low-tech and sufficient for our
+purposes.)
 
 **Exercise 3:** Give a `MonadGamble` instance for the `IO` monad.
 


### PR DESCRIPTION
A student noted to me today at dinner that the exercises call for implementing the [`Random`](https://hackage.haskell.org/package/random-1.2.1.2/docs/System-Random.html#t:Random) class, but its documentation notes that this class now only exists for backwards compatibility and new code should implement `Uniform` or `UniformRange`. However, they ran into trouble because on trying to implement `UniformRange`, GHC gave them an error message about `uniformRM` not being in scope -- which makes sense, because `uniformRM`, the (only) method of `UniformRange`, is not exported from `System.Random`, only from `System.Random.Stateful`.

So I think that either:
1. We need to add a note to the exercise that we actually want the students to implement `Random`, and don't worry about `UniformRange`. This is what I put in this PR. Or:
2. We should update the exercise to ask for implementing `Uniform` or `UniformRange` (probably `Uniform` makes the most sense for this particular exercise) and include a note that the student will have to also import `System.Random.Stateful` for this. (This is quite unclear in the haddocks if you're not aware that this is something you have to look out for.)

I don't mind whichever one we choose, but I wanted to make your life easier by pre-writing one of the two options. Feel free to close this PR and choose some different formulation or option.